### PR TITLE
add setting for vim color

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -24,6 +24,11 @@ let g:airline_theme = 'deus'
 " colorscheme
 syntax on
 colorscheme xcodedark
+highlight Normal ctermbg=none
+highlight NonText ctermbg=none
+highlight LineNr ctermbg=none
+highlight Folded ctermbg=none
+highlight EndOfBuffer ctermbg=none 
 
 " others
 set laststatus=2


### PR DESCRIPTION
## why
- 背景があると書きにくい場合が多々あるため

## what
- 背景色を透明にする設定を.vimrcに追加