### PR TITLE
Kumagai/html

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -41,6 +41,13 @@ set showcmd
 set ruler
 set clipboard+=unnamed
 
+" html
+augroup HTMLANDXML
+  autocmd!
+  autocmd Filetype xml inoremap <buffer> </ </<C-x><C-o>
+  autocmd Filetype html inoremap <buffer> </ </<C-x><C-o>
+augroup END
+
 "===== Preference ===== 
 " File
 filetype on

--- a/.vimrc
+++ b/.vimrc
@@ -41,7 +41,7 @@ set showcmd
 set ruler
 set clipboard+=unnamed
 
-" html
+" HTML
 augroup HTMLANDXML
   autocmd!
   autocmd Filetype xml inoremap <buffer> </ </<C-x><C-o>
@@ -57,6 +57,10 @@ set nowritebackup
 set wildmode=list:longest
 set history=2000
 set shell=fish
+
+" Indent
+set shiftwidth=2
+set tabstop=2
 
 " Search
 set hlsearch


### PR DESCRIPTION
## Why
- HTMLファイルを見やすくしたい
- インデントの幅がおかしい

## What
- .vimrcにHTMLの設定を追加
- `set shiftwidth`と`tabsop`でインデントの深さを調節