### PR TITLE
Add vi mode keybinding for fish

### DIFF
--- a/config.fish
+++ b/config.fish
@@ -5,6 +5,7 @@ set -x FZF_DEFAULT_COMMAND "ag -g ."
 set -x FZF_DEFAULT_COMMAND 'ag --hidden --ignore .git -g ""'
 set -x LANG "en_US.UTF-8"
 set -x LC_CTYPE "en_US.UTF-8"
+fish_vi_key_bindings
 
 
 # alias

--- a/fish/fish_user_key_bindings.fish
+++ b/fish/fish_user_key_bindings.fish
@@ -1,0 +1,3 @@
+function fish_user_key_bindings
+    bind -M insert jj "if commandline -P; commandline -f cancel; else; set fish_bind_mode default; commandline -f backward-char force-repaint; end"
+end

--- a/fish/memo_for_fish.md
+++ b/fish/memo_for_fish.md
@@ -30,7 +30,9 @@ touch ~/.config/fish/config.fish
 export LSCOLORS=gxfxcxdxbxegedabagacad
 ```
 
-# Make 
+# Add Functions 
 ```sh
 ln -sf ~/ghq/github.com/Kumac13/dotfiles/fish/memo.fish ~/.config/fish/functions/
+
+ln -sf ~/ghq/github.com/Kumac13/dotfiles/fish/fish_user_key_bindings.fish ~/.config/fish/functions/
 ```


### PR DESCRIPTION
## why
- fish上でもvimのkeybingingが使いたい

## What
- ~/.config/fish/functions/fish_user_key_bindings.fishの追加
- config.fishにvi modeの設定の追加

[参考](https://stackoverflow.com/questions/48956984/how-to-remap-escape-insert-mode-to-jk-in-fish-shell/48958650#48958650)
